### PR TITLE
Added Template Values

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -78,7 +78,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "sourceParameters",
     "displayName": "Used Source Parameters",
     "simpleValueType": true,
-    "defaultValue": "utm_source,gclid,fbclid",
+    "defaultValue": "utm_source,source,gclid,fbclid",
     "alwaysInSummary": true,
     "valueValidators": [
       {
@@ -100,7 +100,7 @@ ___TEMPLATE_PARAMETERS___
     "displayName": "Awin Source Values",
     "simpleValueType": true,
     "alwaysInSummary": true,
-    "defaultValue": "awin",
+    "defaultValue": "awin,aw",
     "help": "The value passed inside the source parameter used in Awin links. Leave this as \"awin\" if you are unsure. If you use multiple values, separate them using a comma",
     "valueValidators": [
       {


### PR DESCRIPTION
- Added `source` as a default value for the `Used Source Parameters` field.
- Added `aw` as a default value for the `Awin Source Values` field.

These changes reflect a better alignment with the client-side tag and with the current integration process that places `source=aw&sv1=affiliate&sv_campaign_id=!!!id!!!` as the default URL appends on all programs.