### PR TITLE
Fix missing SameSite=None attribute for AWIN server-to-server cookies

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -272,6 +272,7 @@ if(cookiePeriod == 0){
   options = {
     'domain': cookieDomain,
     'path': '/',
+    'samesite': 'none',
     'secure': true,
     'httpOnly':true
   };
@@ -280,6 +281,7 @@ if(cookiePeriod == 0){
   options = {
     'domain': cookieDomain,
     'path': '/',
+    'samesite': 'none',
     'max-age': cookieLength,
     'secure': true,
     'httpOnly':true


### PR DESCRIPTION
**Problem**

When using the Server AWIN Last Clicke Identifier template for server-side GTM, the following cookies are set:

`ServerAwinChannelCookie`

Even though the server responds with Set-Cookie, these cookies are not visible under Application → Storage → Cookies in the browser.

This happens because the cookies are created without the `SameSite=None `attribute, which modern browsers (Chrome, Safari, Edge) block by default for cross-domain cookies.

As a result, AWIN’s diagnostics show:

Issues with the Server-to-Server Cookie
The first-party cookie for Server-to-Server tracking could not be found. If this transaction came via an affiliate link, please make sure that the Server-to-Server cookie is set.

**Solution**

This PR updates the template so that cookies are set with:

```
'samesite': 'none',
'secure': true
```

This ensures compatibility with modern browser cookie policies and fixes the issue where AWIN server-to-server tracking cannot detect first-party cookies.

**Impact**

- Fixes AWIN diagnostics error about missing cookies.
- Ensures ServerAwinChannelCookie is properly set and visible in browser storage.
- Improves reliability of affiliate tracking across Shopify and other ecommerce setups using server-side GTM.